### PR TITLE
Upstream changes for ethd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .env*
 *.swp
+*.swo
+*.swn
 *.bak
 *.original
 custom.yml

--- a/ethd
+++ b/ethd
@@ -5,8 +5,19 @@ __project_name="X Docker"
 __app_name="X node"
 __sample_service="X-geth"
 __docker_exe="docker"
+__old_docker=0
 __compose_exe="docker compose"
+__old_compose=0
 __compose_upgraded=0
+__distro=""
+__os_major_version=""
+__eol_os=0
+__min_ubuntu=22
+__suggest_ubuntu="24.04 or 22.04."
+__upgrade_ubuntu="24.04: https://gist.github.com/yorickdowne/94f1e5538007f4c9d3da7b22b0dc28a4"
+__min_debian=11
+__suggest_debian="12 or 11."
+__upgrade_debian="12: https://gist.github.com/yorickdowne/ec9e2c6f4f8a2ee93193469d285cd54c"
 
 # Also adjust version() and __prep_conffiles for your chain, look for the word "Adjust" below
 # If you are using an init container, adjust start()
@@ -368,7 +379,8 @@ __determine_distro() {
 }
 
 
-__handle_docker_sudo() {
+__handle_docker() {
+  set +e
   if [[ "$__distro" =~ "debian" || "$__distro" = "ubuntu" ]] && ! grep -qi microsoft /proc/version; then
     systemctl status docker >/dev/null
     __result=$?
@@ -379,6 +391,7 @@ __handle_docker_sudo() {
       exit 1
     fi
   fi
+  set -e
 
   __docker_version=$(docker --version | awk '{ gsub(/,/, "", $3); print $3 }')
   __docker_major_version=$(docker --version | awk '{ split($3, version, "."); print version[1]; }')
@@ -421,23 +434,39 @@ __handle_root() {
 __check_compose_version() {
 # Check for Compose V2 (docker compose) vs Compose V1 (docker-compose)
   if docker compose version >/dev/null 2>&1; then
-    __old_compose=0
+    __compose_version=$($__docker_sudo docker compose version | sed -n -E -e "s/.*version [v]?([0-9.-]*).*/\1/ip")
+    __compose_major=${__compose_version%%.*}
+    __compose_minor=${__compose_version#*.}
+    __compose_minor=${__compose_minor%%.*}
+   if [[ "${__compose_major}" -eq 1 ]]; then
+     __old_compose=1
+   elif [[ "${__compose_minor}" -lt 18 ]]; then
+     __old_compose=1
+   else
+     __old_compose=0
+   fi
   else
     __old_compose=1
     __compose_version=$($__docker_sudo docker-compose --version | sed -n -E -e "s/.*version [v]?([0-9.-]*).*/\1/ip")
+  fi
+  if [ "${__old_compose}" -eq 1 ]; then
     if [ -n "${ETHDSECUNDO-}" ]  || [ ! "${__command}" = "update" ]; then # Don't run this twice
       echo
-      echo "You are using docker-compose ${__compose_version}, which is unsupported by Docker, Inc."
-      echo "${__project_name} only supports Compose V2."
-      echo
-      echo "It is recommended that you replace Compose V1 with Compose V2."
-      while true; do
-        read -rp "Do you want to update Docker Compose to V2? (yes/no) " __yn
-        case $__yn in
-          [Nn]* ) echo "Please be sure to update Docker Compose yourself!"; break;;
-           * ) __upgrade_compose; break;;
-        esac
-      done
+      if [[ "${__compose_major}" -eq 1 ]]; then
+        echo "You are using docker-compose ${__compose_version}, which is unsupported by Docker, Inc."
+        echo "${__project_name} only supports Compose V2."
+        echo
+        echo "It is recommended that you replace Compose V1 with Compose V2."
+        while true; do
+          read -rp "Do you want to update Docker Compose to V2? (yes/no) " __yn
+          case $__yn in
+            [Nn]* ) echo "Please be sure to update Docker Compose yourself!"; break;;
+             * ) __upgrade_compose; break;;
+          esac
+        done
+      else
+        true  # Nothing now; maybe in future we'll do the update for the user
+      fi
     fi
   fi
 }
@@ -450,30 +479,16 @@ __upgrade_compose() {
   fi
   echo "Updating Docker Compose to V2"
   if [[ "$__distro" = "ubuntu" ]]; then
-    if [ "${__os_major_version}" -lt 22 ]; then
+     __nag_os_version
+    if [ "${__eol_os}" -eq 1 ]; then
       echo "${__project_name} cannot update Docker Compose on Ubuntu ${__os_major_version}."
-      echo "Consider upgrading to 22.04 and then 24.04."
       exit 1
     fi
-    if dpkg-query -W -f='${Status}' docker.io 2>/dev/null | grep -q "ok installed"; then
-      ${__auto_sudo} apt-mark manual docker.io
-    elif dpkg-query -W -f='${Status}' docker-ce 2>/dev/null | grep -q "ok installed"; then
-      ${__auto_sudo} apt-mark manual docker-ce
-    fi
-    ${__auto_sudo} apt-get remove -y docker-compose
-    echo "Removed docker-compose"
     ${__auto_sudo} apt-get update
     ${__auto_sudo} apt-get install -y docker-compose-v2 docker-buildx
     echo "Installed docker-compose-v2"
     __old_compose=0
     __compose_upgraded=1
-  elif [[ "$__distro" =~ "debian" ]]; then
-    ${__auto_sudo} apt-get update && ${__auto_sudo} apt-get -y install ca-certificates curl gnupg
-    if [ "${__os_major_version}" -lt 11 ]; then
-      echo "${__project_name} cannot update Docker Compose on Debian ${__os_major_version}."
-      echo "Consider upgrading to 11 and then 12."
-      exit 1
-    fi
     if dpkg-query -W -f='${Status}' docker.io 2>/dev/null | grep -q "ok installed"; then
       ${__auto_sudo} apt-mark manual docker.io
     elif dpkg-query -W -f='${Status}' docker-ce 2>/dev/null | grep -q "ok installed"; then
@@ -481,18 +496,34 @@ __upgrade_compose() {
     fi
     ${__auto_sudo} apt-get remove -y docker-compose
     echo "Removed docker-compose"
+  elif [[ "$__distro" =~ "debian" ]]; then
+    ${__auto_sudo} apt-get update && ${__auto_sudo} apt-get -y install ca-certificates curl gnupg
+    __nag_os_version
+    if [ "${__eol_os}" -eq 1 ]; then
+      echo "${__project_name} cannot update Docker Compose on Debian ${__os_major_version}."
+      exit 1
+    fi
     ${__auto_sudo} mkdir -p /etc/apt/keyrings
-    ${__auto_sudo} curl -fsSL https://download.docker.com/linux/debian/gpg | ${__auto_sudo} gpg --dearmor --yes -o /etc/apt/keyrings/docker.gpg
+    ${__auto_sudo} curl -fsSL https://download.docker.com/linux/debian/gpg | ${__auto_sudo} gpg --dearmor --yes \
+    -o /etc/apt/keyrings/docker.gpg
     ${__auto_sudo} echo \
-      "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
-      $(lsb_release -cs) stable" | ${__auto_sudo} tee /etc/apt/sources.list.d/docker.list > /dev/null
+        "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] \
+        https://download.docker.com/linux/debian $(lsb_release -cs) stable" \
+        | ${__auto_sudo} tee /etc/apt/sources.list.d/docker.list > /dev/null
     ${__auto_sudo} apt-get update
     ${__auto_sudo} apt-get install -y docker-compose-plugin docker-buildx-plugin
     echo "Installed docker-compose-plugin"
     __old_compose=0
     __compose_upgraded=1
+    if dpkg-query -W -f='${Status}' docker.io 2>/dev/null | grep -q "ok installed"; then
+      ${__auto_sudo} apt-mark manual docker.io
+    elif dpkg-query -W -f='${Status}' docker-ce 2>/dev/null | grep -q "ok installed"; then
+      ${__auto_sudo} apt-mark manual docker-ce
+    fi
+    ${__auto_sudo} apt-get remove -y docker-compose
+    echo "Removed docker-compose"
   else
-    echo "${__project_name} does not know how to update Docker Compose on $__distro"
+    echo "${__project_name} does not know how to update Docker Compose on ${__distro}"
   fi
 }
 
@@ -515,84 +546,84 @@ __check_for_snap() {
 }
 
 
-install() {
-  if [ "$__cannot_sudo" -eq 1 ]; then
-    echo "The install command requires the user to be part of the sudo group, or on macOS the admin group"
-    exit 1
+__install_docker() {
+  local __repo
+
+
+  if [[ "$__distro" = "ubuntu" ]]; then
+    __repo=ubuntu
+  elif [[ "$__distro" = *"debian"* ]]; then
+    __repo=debian
+  else
+    echo
+    echo "__install_docker() was called on ${__distro}, which is neither Debian nor Ubuntu."
+    echo "This is a bug."
+    exit 70
   fi
 
-  while true; do
-    read -rp "This will attempt to install Docker and make your user part of the docker group. Do you wish to continue? (no/yes) " __yn
-    case $__yn in
-      [Yy]* ) break;;
-      * ) echo "Aborting, no changes made"; exit 130;;
-    esac
-  done
-  if [[ "$__distro" = "ubuntu" ]]; then
-    if [ "${__os_major_version}" -lt 22 ]; then
-      echo "${__project_name} cannot install Docker on Ubuntu ${__os_major_version}."
-      echo "Consider upgrading to 22.04 and then 24.04."
-      exit 1
-    fi
-    if [ -z "$(which docker)" ]; then
-      ${__auto_sudo} apt-get update && ${__auto_sudo} apt-get install -y ca-certificates curl gnupg \
-        chrony pkg-config screen ncdu
-      ${__auto_sudo} mkdir -p /etc/apt/keyrings
-      ${__auto_sudo} curl -fsSL https://download.docker.com/linux/ubuntu/gpg | ${__auto_sudo} gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-      ${__auto_sudo} echo \
-        "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
-        $(lsb_release -cs) stable" | ${__auto_sudo} tee /etc/apt/sources.list.d/docker.list > /dev/null
-      ${__auto_sudo} apt-get update
-      ${__auto_sudo} apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin \
-        docker-buildx-plugin
-      ${__auto_sudo} systemctl start systemd-logind
-      echo "Installed docker-ce and docker-compose-plugin"
-    else
-      echo "Docker is already installed"
-    fi
-    __groups=$(${__as_owner} groups)
-    if [[ ! "$__groups" =~ "docker" ]]; then
-      echo "Making your user part of the docker group"
-      ${__auto_sudo} usermod -aG docker "${OWNER}"
-      echo "Please run newgrp docker or log out and back in"
-    else
-      echo "Your user is already part of the docker group"
-    fi
-  elif [[ "$__distro" =~ "debian" ]]; then
-    if [ -z "$(which docker)" ]; then
-      ${__auto_sudo} apt-get update
-      ${__auto_sudo} apt-get -y install ca-certificates curl gnupg chrony pkg-config screen ncdu
-      if [ "${__os_major_version}" -lt 11 ]; then
-        echo "${__project_name} cannot install Docker on Debian ${__os_major_version}."
-        echo "Consider upgrading to 11 and then 12."
-        exit 1
-      fi
-      ${__auto_sudo} mkdir -p /etc/apt/keyrings
-      ${__auto_sudo} curl -fsSL https://download.docker.com/linux/debian/gpg | ${__auto_sudo} gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-      ${__auto_sudo} echo \
-        "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
-        $(lsb_release -cs) stable" | ${__auto_sudo} tee /etc/apt/sources.list.d/docker.list > /dev/null
-      ${__auto_sudo} apt-get update
-      ${__auto_sudo} apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin \
-        docker-buildx-plugin
-      ${__auto_sudo} systemctl start systemd-logind
-      echo "Installed docker-ce and docker-compose-plugin"
-    else
-      echo "Docker is already installed"
-    fi
-    __groups=$(${__as_owner} groups)
-    if [[ ! "$__groups" =~ "docker" ]]; then
-      echo "Making your user part of the docker group"
-      ${__auto_sudo} usermod -aG docker "${OWNER}"
-      echo "Please run newgrp docker or log out and back in"
-    else
-      echo "Your user is already part of the docker group"
-    fi
+  if [ -z "$(command -v docker)" ]; then
+    ${__auto_sudo} mkdir -p /etc/apt/keyrings
+    curl -fsSL "https://download.docker.com/linux/${__repo}/gpg" | ${__auto_sudo} gpg --dearmor \
+      --yes -o /etc/apt/keyrings/docker.gpg
+    echo \
+      "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] \
+      https://download.docker.com/linux/${__repo} $(lsb_release -cs) stable" \
+      | ${__auto_sudo} tee /etc/apt/sources.list.d/docker.list > /dev/null
+    ${__auto_sudo} apt-get update
+    ${__auto_sudo} apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin \
+      docker-buildx-plugin
+    ${__auto_sudo} systemctl start systemd-logind
+    echo "Installed docker-ce and docker-compose-plugin"
   else
-    echo "${__project_name} does not know how to install Docker on $__distro"
-    exit 1
+    echo "Docker is already installed"
   fi
+
+  local __groups
+  __groups=$(${__as_owner} groups)
+  if [[ ! "${__groups}" =~ "docker" ]]; then
+    echo "Making your user part of the docker group"
+    ${__auto_sudo} usermod -aG docker "${OWNER}"
+    echo "Please run newgrp docker or log out and back in"
+  else
+    echo "Your user is already part of the docker group"
+  fi
+
   return 0
+}
+
+
+install() {
+  if ! [[ "${__distro}" =~ (ubuntu|debian) ]]; then
+    echo "${__project_name} does not know how to install Docker on ${__distro}"
+    return 0
+  fi
+
+  __nag_os_version
+  if [ "${__eol_os}" -eq 1 ]; then
+    echo "${__project_name} requires an upgraded Linux distribution to run install."
+    return 0
+  fi
+
+  if [ "$__cannot_sudo" -eq 1 ]; then
+    echo "The install command requires the user to be part of the sudo group, or on macOS the admin group"
+    return 0
+  fi
+
+  echo "Installing packages that ${__me} requires or considers helpful"
+  echo
+  ${__auto_sudo} apt-get update
+  ${__auto_sudo} apt-get install -y ca-certificates curl gnupg whiptail chrony pkg-config screen ncdu gzip
+
+  echo
+  read -rp "Do you want to install Docker and make your user part of the docker group? (no/yes) " __yn
+  case $__yn in
+    [Yy]* ) __install_docker;;
+    * ) ;;
+  esac
+
+  if [ -n "$(command -v docker)" ]; then
+    __handle_docker
+  fi
 }
 
 
@@ -682,20 +713,27 @@ __check_disk_space() {
 }
 
 
+# Both tells the user that their OS is old, and sets __eol_os for code that requires a min version
 __nag_os_version() {
-  if [[ "$__distro" = "ubuntu" ]]; then
-    if [ "${__os_major_version}" -lt 22 ]; then
-      echo
-      echo "Ubuntu ${__os_major_version} is older than the recommended 24.04 or 22.04 version."
-      echo
-      echo "Updating is neither urgent nor required, merely recommended."
-    fi
-  elif [[ "$__distro" =~ "debian" ]]; then
-    if [ "${__os_major_version}" -lt 11 ]; then
-      echo
-      echo "Debian ${__os_major_version} is older than the recommended 12 or 11 version."
-      echo
-      echo "Updating is neither urgent nor required, merely recommended."
+  if [[ "$__distro" = "ubuntu" && "${__os_major_version}" -lt "${__min_ubuntu}" ]]; then
+     echo
+     echo "Ubuntu ${__os_major_version} is older than the recommended ${__suggest_ubuntu} version."
+     echo
+     echo "Upgrading is highly recommended, so that up-to-date Docker packages are available."
+     echo
+     echo "Guide to upgrading to ${__upgrade_ubuntu}"
+     __eol_os=1
+  fi
+
+  if [[ "$__distro" =~ "debian" ]]; then
+    if [ "${__os_major_version}" -lt "${__min_debian}" ]; then
+     echo
+     echo "Debian ${__os_major_version} is older than the recommended ${__suggest_debian} version."
+     echo
+     echo "Upgrading is highly recommended, so that up-to-date Docker packages are available."
+     echo
+     echo "Guide to upgrading to ${__upgrade_debian}"
+     __eol_os=1
     fi
   fi
 }
@@ -711,6 +749,15 @@ __pull_and_build() {
 # Arguments are passed, but shellcheck doesn't recognize that
 # shellcheck disable=SC2120
 update() {
+  __debug=0
+  if [[ "$*" =~ "--debug" ]]; then
+    __debug=1
+  fi
+  if [[ "$*" =~ "--trace" ]]; then
+    __debug=1
+    set -x
+  fi
+
 # Only one copy of update() should run per stack
   local __script_dir
   __script_dir="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
@@ -791,7 +838,7 @@ update() {
         __non_interactive=1
         shift
         ;;
-      --debug)
+      --debug | --trace)
         __debug=1
         shift
         ;;
@@ -815,6 +862,10 @@ update() {
     ${__as_owner} rm "${__env_file}".source  # .bak was created earlier
     echo "Your ${__env_file} configuration settings have been migrated to a fresh copy. You can \
 find the original contents in ${__env_file}.bak."
+    if [ "${__keep_targets}" -eq 0 ]; then
+      echo "NB: If you made changes to the source or binary build targets, these have been \
+reset to defaults."
+    fi
     echo
     echo "List of changes made to ${__env_file} during migration - current on left, original on right:"
     echo
@@ -938,7 +989,6 @@ __handle_error() {
   fi
 
   local __exit_code=$1
-  local __line_no=$2
   if [ "$__exit_code" -eq 0 ]; then
     return 0
   fi
@@ -948,6 +998,7 @@ __handle_error() {
   fi
   __handler_ran=1
 
+  local __line_no=$2
   echo
   if [ "$__exit_code" -eq 130 ]; then
     echo "$__me terminated by user"
@@ -968,18 +1019,17 @@ __handle_error() {
 
 
 __update_help() {
-  echo "usage: $__me update [--refresh-targets] [--non-interactive] [--debug]"
+  echo "usage: $__me update [--refresh-targets] [--non-interactive] [--debug] [--trace]"
   echo
-  echo "Updates Eth Docker itself, as required the contents of \".env\", and the clients."
+  echo "Updates $__project_name itself, as required the contents of \".env\", and the clients."
   echo
-  echo "A combination of \"git pull\" for Eth Docker, some bash scripting to bring new variables from \"default.env\","
+  echo "A combination of \"git pull\" for $__project_name, some bash scripting to bring new variables from \"default.env\","
   echo "and \"docker compose pull\" as well as \"docker compose build\" for the clients."
-  echo
-  echo "If warranted, will also offer resync when clients require it, or upgrade of PostgreSQL version."
   echo
   echo "\"--refresh-targets\" sets Docker tags, source targets, and repos of clients back to the defaults in \"default.env\"."
   echo "\"--non-interactive\" does not ask questions and assumes Yes for database resyncs and migrations."
   echo "\"--debug\" handles some CI sanity checks."
+  echo "\"--trace\" enables full bash-shell tracing with \"set -x\""
   echo
 }
 
@@ -1038,7 +1088,8 @@ __migrated=0
 __command=""
 __me="./$(basename "${BASH_SOURCE[0]}")"
 
-trap '__handle_error $? $LINENO' ERR EXIT
+trap '__handle_error $? $LINENO' ERR
+trap '__handle_error $? $LINENO' EXIT
 
 if [[ "$#" -eq 0 || "$*" = "--help" || "$*" = "-h" || "$*" = "update --help" || "$*" = "update -h" ]]; then
   help "$@"
@@ -1070,10 +1121,10 @@ if [ "$__command" = "install" ]; then
   exit "$?"
 fi
 
-__handle_docker_sudo
+__handle_docker
 __check_compose_version
 
-if [ "${__old_compose}" -eq 1 ]; then
+if [[ "${__old_compose}" -eq 1 && "${__compose_major}" -eq 1 ]]; then
   echo
   echo "You are using docker-compose ${__compose_version}, which is unsupported by Docker, Inc."
   echo "${__project_name} only supports Compose V2."
@@ -1120,9 +1171,16 @@ if [ "${__compose_upgraded}" -eq 1 ]; then
   echo "You updated Docker Compose to V2."
   echo "The \"docker-compose\" command is gone and replaced with \"docker compose\"."
   echo
-  echo "You can create an alias for \"docker-compose\" by adding this line to your \"~/.profile\":"
-  echo "alias docker-compose=\"docker compose\""
-  echo
   echo "Optionally, you can switch to docker-ce."
   echo "Please see https://ethdocker.com/Usage/Prerequisites#switching-from-dockerio-to-docker-ce for instructions."
+fi
+
+if [[ "${__old_compose}" -eq 1 && "${__compose_major}" -eq 2 ]]; then
+  echo "You are using Docker Compose ${__compose_version}, which has been shown to cause issues with new features"
+  echo "${__project_name} may require Compose v2.18.1 or later in future"
+  echo
+  echo "It is recommended that you update Compose."
+  if [[ ( "$__distro" =~ "debian" || "$__distro" = "ubuntu" ) ]]; then
+    echo "Please do so by running: \"sudo apt update && sudo apt dist-upgrade\""
+  fi
 fi

--- a/ethd
+++ b/ethd
@@ -612,7 +612,7 @@ install() {
   echo "Installing packages that ${__me} requires or considers helpful"
   echo
   ${__auto_sudo} apt-get update
-  ${__auto_sudo} apt-get install -y ca-certificates curl gnupg whiptail chrony pkg-config screen ncdu gzip
+  ${__auto_sudo} apt-get install -y ca-certificates curl gnupg chrony pkg-config screen ncdu
 
   echo
   read -rp "Do you want to install Docker and make your user part of the docker group? (no/yes) " __yn


### PR DESCRIPTION
Improved version handling for OS, Docker and Compose

Better error handler

Cleaned up install command

Better help

Add `--trace` to `update`

Consistently use `=` not `==` for `test` aka `[]`

All from upstream Eth Docker
