### PR TITLE
Stronger linting

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directories:
+      - "*"
+    schedule:
+      interval: "weekly"
+    groups:
+      docker-deps:
+        patterns:
+          - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions-deps:
+        patterns:
+          - "*"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,8 +11,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Lint sources
-        run: |
-          sudo apt-get update && sudo apt-get install -y pre-commit
-          pre-commit run --all-files
+        uses: pre-commit/action@v3.0.1
+        with:
+          extra_args: --all-files --show-diff-on-failure

--- a/.github/workflows/test-update.yml
+++ b/.github/workflows/test-update.yml
@@ -14,7 +14,7 @@ jobs:
   test-update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Docker buildx
         uses: docker/setup-buildx-action@v3
       - name: Create .env file

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,22 +1,52 @@
+---
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
     hooks:
-    - id: trailing-whitespace-fixer
-    - id: end-of-file-fixer
-    - id: check-json
-    - id: check-yaml
-    - id: double-quote-string-fixer
-    - id: check-shebang-scripts-are-executable
-    - id: check-executables-have-shebangs
-    - id: detect-private-key
-    - id: detect-aws-credentials
-repos:
-- repo: https://github.com/jumanjihouse/pre-commit-hooks
-  rev: 3.0.0
-  hooks:
-  - id: shellcheck
-  - id: script-must-have-extension
-  - id: git-dirty
-  - id: git-check
-  - id: forbid-binary
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-json
+      - id: check-yaml
+      - id: check-shebang-scripts-are-executable
+      - id: check-executables-have-shebangs
+      - id: detect-private-key
+      - id: check-ast
+      - id: debug-statements
+      - id: check-merge-conflict
+      - id: check-added-large-files
+      - id: mixed-line-ending
+      - id: check-case-conflict
+      - id: requirements-txt-fixer
+      - id: check-toml
+
+  - repo: https://github.com/jumanjihouse/pre-commit-hooks
+    rev: 3.0.0
+    hooks:
+      - id: shellcheck
+      - id: script-must-have-extension
+      - id: git-dirty
+      - id: git-check
+      - id: forbid-binary
+
+  # Spelling (nice quality-of-life)
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+      - id: codespell
+
+  # Dockerfiles
+  # Disabled bcs macOS Docker might not be installed
+  # - repo: https://github.com/hadolint/hadolint
+  #   rev: v2.13.1
+  #   hooks:
+  #     - id: hadolint-docker
+
+  # YAML style (beyond syntax)
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.37.1
+    hooks:
+      - id: yamllint
+        args:
+          - -d
+          - >
+            {extends: default, rules: {line-length: {max: 120},document-start: disable,truthy: disable}}

--- a/README.md.example
+++ b/README.md.example
@@ -9,19 +9,19 @@ If you want the RPC ports exposed locally, use `rpc-shared.yml` in `COMPOSE_FILE
 
 ## Quick Start
 
-The `./projectd` script can be used as a quick-start:
+The `./<project>d` script can be used as a quick-start:
 
-`./projectd install` brings in docker-ce, if you don't have Docker installed already.
+`./<project>d install` brings in docker-ce, if you don't have Docker installed already.
 
 `cp default.env .env`
 
 `nano .env` and adjust variables as needed, particularly mention-important-vars-here
 
-`./projectd up`
+`./<project>d up`
 
 ## Software update
 
-To update the software, run `./projectd update` and then `./projectd up`
+To update the software, run `./<project>d update` and then `./<project>d up`
 
 ## Customization
 


### PR DESCRIPTION
Add additional pre-commits, and add dependabot

Not for Python, as most of our projects don't use Python. Those that do should add Python linting and dependabot independently.
