### PR TITLE
Handle multi-line sinqle-quote in .env

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @galaxy-ggatheca @galaxy-mario @galaxysrechris
+* @galaxy-ggatheca @galaxysrechris

--- a/ethd
+++ b/ethd
@@ -6,6 +6,8 @@ __app_name="X node"
 __sample_service="X-geth"
 __docker_exe="docker"
 __old_docker=0
+__docker_sudo=""
+__docker_major_version=""
 __compose_exe="docker compose"
 __old_compose=0
 __compose_upgraded=0
@@ -18,6 +20,28 @@ __upgrade_ubuntu="24.04: https://gist.github.com/yorickdowne/94f1e5538007f4c9d3d
 __min_debian=11
 __suggest_debian="12 or 11."
 __upgrade_debian="12: https://gist.github.com/yorickdowne/ec9e2c6f4f8a2ee93193469d285cd54c"
+__non_interactive=0
+__debug=0
+__found=0
+__env_file=.env
+__during_update=0
+__during_migrate=0
+__migrated=0
+__keep_targets=1
+__target_ver=1
+__source_ver=1
+__handler_ran=0
+__command=""
+__params=""
+__me=./ethd
+__auto_sudo=""
+__cannot_sudo=0
+__as_owner=""
+__owner=""
+__value=""  # This is a global to hand a result back from __get_value_from_env
+__free_space=0
+__docker_dir="/var/lib/docker"
+
 
 # Also adjust version() and __prep_conffiles for your chain, look for the word "Adjust" below
 # If you are using an init container, adjust start()
@@ -30,10 +54,12 @@ version() {
   __get_value_from_env "${__var}" "${__env_file}" "__value"
 # Client versions
 # Adjust for your clients and how to check their version
+# Multiple clients are in multiple case statements. Mutually exclusive clients are in one case statement
+# Avoid the use of ;;&
   case "${__value}" in
     *x.yml* )
       __docompose exec x-geth x-geth version
-      ;;&
+      ;;
   esac
 }
 
@@ -179,156 +205,209 @@ __docompose() {
 
 
 __get_value_from_env() {
-  # Call with variable name to read, env file name, and global variable to assign the value to
+  # Call with variable name to read, env file name, and global variable to assign the __value to
   # Also sets global __found
-  local __var_name="$1"
-  local __env_file="$2"
-  local __output_var="$3"
-  local __output
-  local __parsed_value
+  local var_name="$1"
+  local env_file="$2"
+  local output_var="$3"
+  local output
+  local parsed_value
+  local awk_exe
 
-  if [[ "${__output_var}" = "__parsed_value" || "${__output_var}" = "__output_var" \
-      || "${__output_var}" = "__output" || "${__output_var}" = "__env_file" \
-      || "${__output_var}" = "__var_name" ]]; then
-    echo "__get_value_from_env was called with a conflicting output variable: $__output_var"
+  if [[ "${output_var}" = "parsed_value" || "${output_var}" = "output_var" \
+      || "${output_var}" = "output" || "${output_var}" = "env_file" \
+      || "${output_var}" = "var_name" ]]; then
+    echo "__get_value_from_env was called with a conflicting output variable: ${output_var}"
     echo "This is a bug."
     exit 70
   fi
 
-  __output=$(awk -v var="$__var_name" '
+  if [[ "$OSTYPE" = "darwin"* ]]; then
+    awk_exe="gawk"  # Built-in awk can't handle multi-line. Does require brew install gawk
+  else
+    awk_exe="awk"
+  fi
+
+#shellcheck disable=SC2016
+  output=$(${awk_exe} -v var="${var_name}" '
     BEGIN { __found = 0; __value = "" }
 
     # Skip empty lines and comments
-    /^#|^\s*$/ {
+    /^[[:space:]]*($|#)/ {
       next
     }
 
-    # Match single-line unquoted value
-    $0 ~ "^[ \t]*"var"=[^\"].*$" {
-      gsub("^[ \t]*"var"=", "")
+    # Match single-line unquoted __value
+    $0 ~ "^[ \t]*" var "=" && $0 !~ "^[ \t]*" var "=[ \t]*[\"'\'']" {
+      sub("^[ \t]*"var"=", "")
       gsub(/^[ \t]*|[ \t]*$/, "", $0)
       __value = $0
       __found = 1
       exit
     }
 
-    # Match empty unquoted value
+    # Match empty unquoted __value
     $0 ~ "^[ \t]*"var"=$" {
-       __value = ""
-       __found = 1
-       exit
+      __value = ""
+      __found = 1
+      exit
     }
 
-    # Match a quoted single-line value
-    $0 ~ "^[ \t]*"var"=\"[^\"]*\"[ \t]*$" {
-      gsub("^[ \t]*"var"=\"", "")
-      gsub(/"[ \t]*$/, "", $0)
+    # Single-line DOUBLE-quoted: VAR="..."; allow trailing spaces
+    $0 ~ "^[ \t]*" var "=\"[^\"]*\"[ \t]*$" {
+      sub("^[ \t]*" var "=\"", "", $0)
+      sub(/"[ \t]*$/, "", $0)
       __value = "\"" $0 "\""
       __found = 1
       exit
     }
 
-    # Match the start of a multi-line value (with opening quote)
-    $0 ~ "^[ \t]*"var"=\"[^\"]*$" {
-      gsub("^[ \t]*"var"=\"", "")
-      __value = "\"" $0 "\n"
+    # Single-line SINGLE-quoted: VAR='\''...'\''; allow trailing spaces
+    $0 ~ "^[ \t]*" var "='\''[^'\'']*'\''[ \t]*$" {
+      sub("^[ \t]*" var "='\''", "", $0)
+      sub(/'\''[ \t]*$/, "", $0)
+      __value = "'"'"'" $0 "'"'"'"
+      __found = 1
+      exit
+    }
+
+    # Match the start of a multi-line __value (with opening double or single quote)
+    $0 ~ "^[ \t]*"var"=\"[^\"]*$" || $0 ~ "^[ \t]*" var "='\''[^'\'']*$" {
+      # Pick which quote we matched and strip the var=<quote> prefix
+      if ($0 ~ "^[ \t]*" var "=\"[^\"]*$") {
+        __q="\""; sub("^[ \t]*" var "=\"", "", $0)
+      } else {
+        __q="'\''";  sub("^[ \t]*" var "='\''", "", $0)
+      }
+      # Accumulator starts with the opening quote, plus first chunk + newline
+      __value = __q $0 "\n"
       __found = 1
       next
     }
 
-    # Continue collecting lines for a multi-line value
-    __found && !/"[ \t]*$/ {
+    # Continue collecting lines for a multi-line __value
+    __found && ($0 !~ (__q=="\"" ? "\"[ \t]*$" : "'\''[ \t]*$")) {
       __value = __value $0 "\n"
       next
     }
 
-    # End of a multi-line value (with closing quote)
-    __found && /"[ \t]*$/ {
-      gsub(/[ \t]*"[ \t]*$/, "")
-      __value = __value $0 "\""
+    # End of a multi-line __value (with closing quote)
+    __found && ($0 ~ (__q=="\"" ? "\"[ \t]*$" : "'\''[ \t]*$")) {
+      # Remove the trailing quote + any spaces/tabs around it
+      if (__q == "\"") {
+        sub(/[ \t]*"[ \t]*$/, "", $0)
+      } else {
+        sub(/[ \t]*'\''[ \t]*$/, "", $0)
+      }
+      __value = __value $0 __q
       __found = 1
       exit
     }
 
     END {
       # Print here-doc style so we can parse with awk
-      # Print the value as is, including quotes for multi-line
+      # Print the __value as is, including quotes for multi-line
       print "__value<<EOF"
       print __value
       print "EOF"
       print "__found=" __found
     }
-  ' "$__env_file")
+  ' "${env_file}")
 
   # Parse __value using here-doc style
-  __parsed_value=$(awk '/^__value<<EOF$/ {getline; while ($0 != "EOF") { print; getline } }' <<< "$__output")
+#shellcheck disable=SC2016
+  parsed_value=$(${awk_exe} '/^__value<<EOF$/ {getline; while ($0 != "EOF") { print; getline } }' <<< "${output}")
   # Parse __found directly into a global variable
-  __found=$(awk -F= '/^__found=/ {print $2}' <<< "$__output")
+#shellcheck disable=SC2016
+  __found=$(${awk_exe} -F= '/^__found=/ {print $2}' <<< "${output}")
 
-  # assign value to caller’s variable
-  printf -v "$__output_var" '%s' "$__parsed_value"
+  # assign __value to caller’s variable
+  printf -v "${output_var}" '%s' "${parsed_value}"
 }
 
 
 __update_value_in_env() {
-# Call as __update_value_in_env "$__var" "$__value" "$__env_file"
-  local __var_name="$1"
-  local __new_value="$2"
-  local __env_file="$3"
+# Call as __update_value_in_env "${var}" "${value}" "${env_file}"
+  local var_name="$1"
+  local new_value="$2"
+  local env_file="$3"
+  local escaped_value
+  local awk_exe
+
+  if [[ "$OSTYPE" = "darwin"* ]]; then
+    awk_exe="gawk"  # Built-in awk can't handle multi-line. Does require brew install gawk
+  else
+    awk_exe="awk"
+  fi
 
   # Escape backslashes for safety
-  local __escaped_value
-  __escaped_value=$(printf '%s' "${__new_value}" | sed 's/\\/\\\\/g')
+  escaped_value=$(printf '%s' "${new_value}" | sed 's/\\/\\\\/g')
 
   # Check if the variable already exists in the .env file
-  if grep -q "^[ \t]*${__var_name}=" "${__env_file}"; then
+  if grep -q "^[ \t]*${var_name}=" "${env_file}"; then
     # Variable exists, update it
-    awk -v var="${__var_name}" -v new_value="${__escaped_value}" '
-      BEGIN { in_block = 0; multi_line = 0 }
-
-      # Match the line that starts with the variable name
+#shellcheck disable=SC2016
+    ${awk_exe} -v var="${var_name}" -v new_value="${escaped_value}" '
+      BEGIN { in_block = 0; multi_line = 0; __q="" }
+      # Start of the target variable
       $0 ~ "^[ \t]*" var "=" {
-        # If the value starts with a quote, it may be a multi-line
+        # Determine opening quote (if any)
         if ($0 ~ "^[ \t]*" var "=\"") {
-          # Start of multi-line value
-          multi_line = 1
-          # Print the variable name with the new value, replacing & safely
-          gsub(/&/, "\\&", new_value)
-          print var "=" new_value
-        } else {
-          # Single-line value
-          gsub(/&/, "\\&", new_value)
-          print var "=" new_value
+          __q = "\""
+          # If there is NOT a second " later on the line, it is multiline
+          if ($0 !~ "^[ \t]*" var "=\".*\"[ \t]*$")
+            multi_line = 1
+          else
+            multi_line = 0
         }
-        # Set the flag to indicate we are processing the target variable block
+        else if ($0 ~ "^[ \t]*" var "='\''") {
+          __q = "'\''"
+          # If there is NOT a second '\'' later on the line, it is multiline
+          if ($0 !~ "^[ \t]*" var "='\''.*'\''[ \t]*$")
+            multi_line = 1
+          else
+            multi_line = 0
+        }
+        else {
+          __q = ""
+          multi_line = 0
+        }
+
+        # Replace with new value, verbatim (already escaped upstream)
+        gsub(/&/, "\\&", new_value)   # AWK print safety
+        print var "=" new_value
+
         in_block = 1
         next
       }
 
-      # If we encounter a new variable definition, stop skipping lines
-      /^[A-Z_][A-Z0-9_]*=/ && in_block {
-        in_block = 0
-        multi_line = 0
+      # A new variable definition resets skipping
+      /^[ \t]*[A-Z_][A-Z0-9_]*=/ && in_block {
+        in_block=0
+        multi_line=0
+        __q=""
       }
-      # Continue to skip lines in a multi-line block if multi_line is true
-      multi_line && !/"[ \t]*$/ {
+
+      # Skip multiline content until closing quote line
+      multi_line && ( $0 !~ (__q=="\"" ? "\"[ \t]*$" : "'\''[ \t]*$") ) {
         next
       }
 
-      # If we reach the end of a multi-line value, reset flags
-      multi_line && /"[ \t]*$/ {
-        in_block = 0
-        multi_line = 0
+      # Closing line of the multi-line block: consume it and reset
+      multi_line && ( $0 ~ (__q=="\"" ? "\"[ \t]*$" : "'\''[ \t]*$") ) {
+        in_block=0
+        multi_line=0
+        __q=""
         next
       }
 
       # Print all lines if not in the target variable block
       { print }
-    ' "${__env_file}" | ${__as_owner} tee "${__env_file}.tmp" >/dev/null
-    ${__as_owner} mv "${__env_file}.tmp" "${__env_file}"
+    ' "${env_file}" | ${__as_owner} tee "${env_file}.tmp" >/dev/null
+    ${__as_owner} mv "${env_file}.tmp" "${env_file}"
   else
     # Variable does not exist, append it
-    printf "%s=%s\n" "${__var_name}" "${__escaped_value}" | ${__as_owner} tee -a "${__env_file}" >/dev/null
+    printf "%s=%s\n" "${var_name}" "${escaped_value}" | ${__as_owner} tee -a "${env_file}" >/dev/null
   fi
 }
 
@@ -417,7 +496,7 @@ __handle_docker() {
 __handle_root() {
   __cannot_sudo=0
   if [ "${EUID}" -eq 0 ]; then
-    __as_owner="sudo -u ${OWNER}"
+    __as_owner="sudo -u ${__owner}"
     __auto_sudo=""
   else
     __as_owner=""
@@ -582,7 +661,7 @@ __install_docker() {
   __groups=$(${__as_owner} groups)
   if [[ ! "${__groups}" =~ "docker" ]]; then
     echo "Making your user part of the docker group"
-    ${__auto_sudo} usermod -aG docker "${OWNER}"
+    ${__auto_sudo} usermod -aG docker "${__owner}"
     echo "Please run newgrp docker or log out and back in"
   else
     echo "Your user is already part of the docker group"
@@ -1101,9 +1180,9 @@ fi
 cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 # Use this to make sure root doesn't end up owning files
 # shellcheck disable=SC2012
-OWNER=$(ls -ld . | awk '{print $3}')
+__owner=$(ls -ld . | awk '{print $3}')
 
-if [ "${OWNER}" = "root" ]; then
+if [ "${__owner}" = "root" ]; then
   echo "Please install ${__project_name} as a non-root user."
   exit 0
 fi


### PR DESCRIPTION
This takes some changes from upstream, but not all

Single-quote multi-line variables in `.env` are supported, courtesy of Eth Docker via Linea Docker

macOS support with using `gawk` there

List all global vars up front

Not taken from Eth Docker, this could be a separate PR if desired:
- Only global vars start with `__`
- Better handling of Docker version and OS version, detection of runc vulns
